### PR TITLE
Update useItemsActions.lua

### DIFF
--- a/client/useItemsActions.lua
+++ b/client/useItemsActions.lua
@@ -89,16 +89,17 @@ RegisterNetEvent('vorpmetabolism:useItem', function(index, label)
         PlayAnimDrink(Config["ItemsToUse"][index]["PropName"])
     end
 
-    if (Config["ItemsToUse"][index]["Effect"] ~= "") then
-        ScreenEffect(Config["ItemsToUse"][index]["Effect"], Config["ItemsToUse"][index]["EffectDuration"])
-    end
+	if (Config["ItemsToUse"][index]["Effect"] ~= "") then
+		ScreenEffect(Config["ItemsToUse"][index]["Effect"], Config["ItemsToUse"][index]["EffectDuration"])
+	end
         
     TriggerEvent("vorp:Tip", string.format(Translation["OnUseItem"], label), 3000)
 end)
 
-function ScreenEffect(effect, time)
+function ScreenEffect(effect, durationMinutes)
+    local durationMilliseconds = durationMinutes * 60000 -- Convert minutes to milliseconds
     AnimpostfxPlay(effect)
-    Citizen.Wait(time)
+    Citizen.Wait(durationMilliseconds)
     AnimpostfxStop(effect)
 end
 


### PR DESCRIPTION
Time didn't have any meaning behind it so a value of one in the effect duration via config would result in it lasting forever, now a value of one will last one minute. Tested In-game as well before and after.